### PR TITLE
Problems authorising with dropbox

### DIFF
--- a/files/authorize.js
+++ b/files/authorize.js
@@ -31,7 +31,7 @@ try {
 	dropboxdProcess.stdout.on('data', function(data) {
 		var resultString = String(data);
 		if (typeof hostId === 'undefined') {
-			var match = /host_id=(.*?)[&|]/.exec(resultString);
+			var match = /host_id=(.*?)[&| ]/.exec(resultString);
 			if (!match) {
 				if (resultString == 'This client is not linked to any account...') {
 					// we didn't receive the host_id in the `data`. Try again.

--- a/files/authorize.js
+++ b/files/authorize.js
@@ -31,9 +31,15 @@ try {
 	dropboxdProcess.stdout.on('data', function(data) {
 		var resultString = String(data);
 		if (typeof hostId === 'undefined') {
-			var match = /host_id=(.*?)&/.exec(resultString);
+			var match = /host_id=(.*?)[&|]/.exec(resultString);
 			if (!match) {
-				die('Unexpected output: ' + resultString);
+				if (resultString == 'This client is not linked to any account...') {
+					// we didn't receive the host_id in the `data`. Try again.
+					return;
+				}
+				else {
+					die('Unexpected output: ' + resultString);
+				}
 			}
 			hostId = match[1];
 			console.log('Retrieved host_id, starting login procedure');


### PR DESCRIPTION
I had 2 problems authorising with dropbox:
1. The existing regex wasn't matching the string "Please visit https://www.dropbox.com/cli_link?host_id=c2fd38a8ed4b0374d2ea12ce195d74eb to link this machine." because the host_id was followed by a space, not a &.
2. Sometimes dropbox wouldn't return only "This client is not linked to any account...", without the host id.

I've updated the regex and update the code to expect to receive "This client is not linked to any account..." without the host_id, and to try again if it happens.

I'm using Ubuntu 10.4.
