### PR TITLE
Make node command configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class dropbox::config(
   $dx_uid   = $dropbox::params::dx_uid,
   $dx_gid   = $dropbox::params::dx_gid,
   $dx_home  = $dropbox::params::dx_home,
+  $dx_node  = $dropbox::params::dx_node,
   ) inherits dropbox::params {
 
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -63,7 +63,7 @@ class dropbox::package {
     }
 
     exec { 'authorize-dropbox-user':
-      command => "node ${dropbox::config::dx_home}/authorize.js ${dropbox::config::user} ${dropbox::config::password}",
+      command => "${dropbox::config::dx_node} ${dropbox::config::dx_home}/authorize.js ${dropbox::config::user} ${dropbox::config::password}",
       user    => $dropbox::config::dx_uid,
       group   => $dropbox::config::dx_gid,
       cwd     => $dropbox::config::dx_home,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,4 +2,5 @@ class dropbox::params {
   $dx_uid = 'dropbox'
   $dx_gid = 'dropbox'
   $dx_home = '/opt/dropbox'
+  $dx_node = 'node'
 }


### PR DESCRIPTION
In Ubuntu 14.04, at the very least, the 'nodejs' package creates a command called 'nodejs', not 'node'.  Allow the command name to be configurable.
